### PR TITLE
Fix absolute urls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Written in 2010-2015 by David E. Jones - jonesde
 Written in 2015 by Sam Hamilton - samhamilton
 Written in 2015 by Abdullah Shaikh - abdullahs
 Written in 2015 by Yao Chunlin - chunlinyao
+Written in 2015 by Jens Hardings - jenshp
 
 ===========================================================================
 
@@ -62,3 +63,4 @@ Signed by git commit adding my legal name and git username:
 Written in 2010-2015 by David E. Jones - jonesde
 Written in 2015 by Yao Chunlin - chunlinyao
 Written in 2015 by Sam Hamilton - samhamilton
+Written in 2015 by Jens Hardings - jenshp

--- a/screen/PopCommerceRoot/Customer/OrderDetail.xml
+++ b/screen/PopCommerceRoot/Customer/OrderDetail.xml
@@ -68,7 +68,7 @@ along with this software (see the LICENSE.md file). If not, see
                             </default-field></field>
                             <field name="description">
                                 <conditional-field condition="productId">
-                                    <link text="${itemDescription} [${productId}]" url="/popc/Product/Detail/${productId}/${itemDescription?.replace(' ', '-')}" url-type="plain" link-type="anchor"/>
+                                    <link text="${itemDescription} [${productId}]" url="/popc/Product/Detail/${productId}/${itemDescription?.replace(' ', '-')}" link-type="anchor"/>
                                     <!-- <display-entity entity-name="Product" text="${productName} [${productId}]" also-hidden="false"/> -->
                                 </conditional-field>
                                 <default-field title="Description"><display text="${itemDescription}"/></default-field>

--- a/screen/PopCommerceRoot/Home.xml
+++ b/screen/PopCommerceRoot/Home.xml
@@ -50,7 +50,7 @@ along with this software (see the LICENSE.md file). If not, see
             
             <field name="productId"><default-field><hidden/></default-field></field>
             <field name="productName"><default-field title="">
-                <link text="${productName}" url="/popc/Product/Detail/${productId}/${productName?.replace(' ', '-')}" url-type="plain" link-type="anchor"/>
+                <link text="${productName}" url="/popc/Product/Detail/${productId}/${productName?.replace(' ', '-')}" link-type="anchor"/>
             </default-field></field>
             <field name="price"><default-field title=""><display also-hidden="false" currency-unit-field="priceUomId"/></default-field></field>
             <field name="quantity"><default-field title=""><text-line size="2" default-value="1"/></default-field></field>

--- a/screen/PopCommerceRoot/Order/Cart.xml
+++ b/screen/PopCommerceRoot/Order/Cart.xml
@@ -40,7 +40,7 @@ along with this software (see the LICENSE.md file). If not, see
             </default-field></field>
             <field name="description">
                 <conditional-field condition="productId">
-                    <link text="${itemDescription} [${productId}]" url="/popc/Product/Detail/${productId}/${itemDescription?.replace(' ', '-')}" url-type="plain" link-type="anchor"/>
+                    <link text="${itemDescription} [${productId}]" url="/popc/Product/Detail/${productId}/${itemDescription?.replace(' ', '-')}" link-type="anchor"/>
                     <!-- <display-entity entity-name="Product" text="${productName} [${productId}]" also-hidden="false"/> -->
                 </conditional-field>
                 <default-field title="Description"><display text="${itemDescription}"/></default-field>

--- a/screen/PopCommerceRoot/Product/Search.xml
+++ b/screen/PopCommerceRoot/Product/Search.xml
@@ -74,7 +74,7 @@ along with this software (see the LICENSE.md file). If not, see
 
             <field name="productId"><default-field><hidden/></default-field></field>
             <field name="productName" entry-name="product.productName"><default-field title="">
-                <link text="${product.productName}" url="/popc/Product/Detail/${productId}/${product.productName?.replace(' ', '-')}" url-type="plain" link-type="anchor"/>
+                <link text="${product.productName}" url="/popc/Product/Detail/${productId}/${product.productName?.replace(' ', '-')}" link-type="anchor"/>
             </default-field></field>
             <field name="price"><default-field title=""><display also-hidden="false" currency-unit-field="priceUomId"/></default-field></field>
             <field name="quantity"><default-field title=""><text-line size="2" default-value="1"/></default-field></field>


### PR DESCRIPTION
When Moqui is mounted at a different location than root, links that use the absolute URL, like "/popc/Product/Detail..." fail.

While using relative URLs fixes the problem, in this case I changed the url-type to the default (screen-path) by eliminating the url-type="plain" attribute which seems to be a more robust solution.